### PR TITLE
Suggest method for auto-complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ curl localhost:20051/search\?q\=armed
  
  or navigate to <http://localhost:20051/search?q=armed>
  
+#### Query for suggestion
+```
+curl localhost:20051/suggest?q=armed
+```
+
+Note: The suggest endpoint gives far less information and is optimised for auto-completion and quick look searches.
 
 ### Configuration
 

--- a/handler/search.go
+++ b/handler/search.go
@@ -61,7 +61,7 @@ func Suggest(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		log.Error(err, log.Data{
 			"message": "Error running an auto-complete (suggest) query.",
-			"query": query})
+			"query":   query})
 		results = &model.SearchResponse{}
 		results.Results = make([]*model.Document, 0)
 	}

--- a/handler/search.go
+++ b/handler/search.go
@@ -53,3 +53,32 @@ func Search(w http.ResponseWriter, req *http.Request) {
 		log.Error(err, log.Data{"message": "Error writing response body"})
 	}
 }
+
+func Suggest(w http.ResponseWriter, req *http.Request) {
+	query := req.URL.Query().Get("q")
+
+	results, err := SearchClient.Suggest(query)
+	if err != nil {
+		log.Error(err, log.Data{
+			"message": "Error running an auto-complete (suggest) query.",
+			"query": query})
+		results = &model.SearchResponse{}
+		results.Results = make([]*model.Document, 0)
+	}
+
+	responseJSON, err := json.Marshal(results)
+	if err != nil {
+		log.Error(err, log.Data{
+			"message": "Error serialising the search results to JSON",
+			"query":   query,
+			"results": results})
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Add("content-type", "application/json")
+	_, err = w.Write(responseJSON)
+	if err != nil {
+		log.Error(err, log.Data{"message": "Error writing response body"})
+	}
+}

--- a/handler/search_test.go
+++ b/handler/search_test.go
@@ -147,7 +147,6 @@ func Test(t *testing.T) {
 		})
 	})
 
-
 	Convey("Given a suggest request", t, func() {
 
 		recorder := httptest.NewRecorder()

--- a/handler/search_test.go
+++ b/handler/search_test.go
@@ -219,34 +219,4 @@ func Test(t *testing.T) {
 			})
 		})
 	})
-
-	Convey("Given a suggest request", t, func() {
-
-		recorder := httptest.NewRecorder()
-		requestBodyReader := bytes.NewReader([]byte("{not a valid document}"))
-		request, _ := http.NewRequest("GET", "/search?q=armed", requestBodyReader)
-
-		Convey("When the query handler is called and the search area client returns an error", func() {
-
-			mockSearchClient := searchtest.NewMockSearchClient()
-			mockSearchClient.CustomQueryFunc = func(term string, index string) (*model.SearchResponse, error) {
-
-				if index == config.ElasticSearchIndex {
-					return mockSuggestResponse, nil
-				}
-
-				return nil, errors.New("search client error")
-			}
-			handler.SearchClient = mockSearchClient
-			handler.Suggest(recorder, request)
-
-			Convey("Then the result has an empty results array", func() {
-				So(recorder.Code, ShouldEqual, http.StatusOK)
-
-				actualResponse := &model.SearchResponse{}
-				_ = json.Unmarshal(recorder.Body.Bytes(), actualResponse)
-				So(len(actualResponse.AreaResults), ShouldEqual, 0)
-			})
-		})
-	})
 }

--- a/handler/search_test.go
+++ b/handler/search_test.go
@@ -38,6 +38,11 @@ func Test(t *testing.T) {
 		TotalResults: 2,
 	}
 
+	mockSuggestResponse := &model.SearchResponse{
+		Results:      documents,
+		TotalResults: 2,
+	}
+
 	Convey("Given a search request", t, func() {
 
 		recorder := httptest.NewRecorder()
@@ -113,6 +118,110 @@ func Test(t *testing.T) {
 	})
 
 	Convey("Given a search request", t, func() {
+
+		recorder := httptest.NewRecorder()
+		requestBodyReader := bytes.NewReader([]byte("{not a valid document}"))
+		request, _ := http.NewRequest("GET", "/search?q=armed", requestBodyReader)
+
+		Convey("When the query handler is called and the search area client returns an error", func() {
+
+			mockSearchClient := searchtest.NewMockSearchClient()
+			mockSearchClient.CustomQueryFunc = func(term string, index string) (*model.SearchResponse, error) {
+
+				if index == config.ElasticSearchIndex {
+					return mockSearchResponse, nil
+				}
+
+				return nil, errors.New("search client error")
+			}
+			handler.SearchClient = mockSearchClient
+			handler.Search(recorder, request)
+
+			Convey("Then the result has an empty results array", func() {
+				So(recorder.Code, ShouldEqual, http.StatusOK)
+
+				actualResponse := &model.SearchResponse{}
+				_ = json.Unmarshal(recorder.Body.Bytes(), actualResponse)
+				So(len(actualResponse.AreaResults), ShouldEqual, 0)
+			})
+		})
+	})
+
+
+	Convey("Given a search request", t, func() {
+
+		recorder := httptest.NewRecorder()
+		requestBodyReader := bytes.NewReader([]byte("{not a valid document}"))
+		request, _ := http.NewRequest("GET", "/search?q=armed", requestBodyReader)
+
+		Convey("When the query handler is called", func() {
+
+			mockSearchClient := searchtest.NewMockSearchClient()
+			handler.SearchClient = mockSearchClient
+			handler.Search(recorder, request)
+
+			Convey("Then the search client is called with the expected parameters", func() {
+				So(recorder.Code, ShouldEqual, http.StatusOK)
+				So(mockSearchClient.QueryRequests[0], ShouldEqual, "armed")
+			})
+		})
+	})
+
+	Convey("Given a suggest request", t, func() {
+
+		recorder := httptest.NewRecorder()
+		requestBodyReader := bytes.NewReader([]byte("{not a valid document}"))
+		request, _ := http.NewRequest("GET", "/suggest?q=armed", requestBodyReader)
+
+		Convey("When the query handler is called", func() {
+
+			mockSearchClient := searchtest.NewMockSearchClient()
+			mockSearchClient.CustomQueryFunc = func(term string, index string) (*model.SearchResponse, error) {
+				return mockSuggestResponse, nil
+			}
+			handler.SearchClient = mockSearchClient
+			handler.Suggest(recorder, request)
+
+			Convey("Then the response contains the content returned from the search client.", func() {
+				So(recorder.Code, ShouldEqual, http.StatusOK)
+
+				actualResponse := &model.SearchResponse{}
+				_ = json.Unmarshal(recorder.Body.Bytes(), actualResponse)
+
+				So(actualResponse.TotalResults, ShouldEqual, mockSearchResponse.TotalResults)
+				So(actualResponse.Results[0].ID, ShouldEqual, mockSearchResponse.Results[0].ID)
+				So(actualResponse.Results[1].ID, ShouldEqual, mockSearchResponse.Results[1].ID)
+			})
+		})
+	})
+
+	Convey("Given a suggest request", t, func() {
+
+		recorder := httptest.NewRecorder()
+		requestBodyReader := bytes.NewReader([]byte("{not a valid document}"))
+		request, _ := http.NewRequest("GET", "/suggst?q=armed", requestBodyReader)
+
+		Convey("When the query handler is called and the search client returns an error", func() {
+
+			mockSearchClient := searchtest.NewMockSearchClient()
+			mockSearchClient.CustomQueryFunc = func(term string, index string) (*model.SearchResponse, error) {
+				return nil, errors.New("search client error")
+			}
+			handler.SearchClient = mockSearchClient
+			handler.Search(recorder, request)
+
+			Convey("Then the result has an empty results array", func() {
+				So(recorder.Code, ShouldEqual, http.StatusOK)
+
+				actualResponse := &model.SearchResponse{}
+				_ = json.Unmarshal(recorder.Body.Bytes(), actualResponse)
+
+				So(actualResponse.TotalResults, ShouldEqual, 0)
+			})
+		})
+	})
+
+	Convey("Given a suggest request", t, func() {
 
 		recorder := httptest.NewRecorder()
 		requestBodyReader := bytes.NewReader([]byte("{not a valid document}"))

--- a/handler/search_test.go
+++ b/handler/search_test.go
@@ -148,7 +148,7 @@ func Test(t *testing.T) {
 	})
 
 
-	Convey("Given a search request", t, func() {
+	Convey("Given a suggest request", t, func() {
 
 		recorder := httptest.NewRecorder()
 		requestBodyReader := bytes.NewReader([]byte("{not a valid document}"))
@@ -158,7 +158,7 @@ func Test(t *testing.T) {
 
 			mockSearchClient := searchtest.NewMockSearchClient()
 			handler.SearchClient = mockSearchClient
-			handler.Search(recorder, request)
+			handler.Suggest(recorder, request)
 
 			Convey("Then the search client is called with the expected parameters", func() {
 				So(recorder.Code, ShouldEqual, http.StatusOK)
@@ -188,9 +188,8 @@ func Test(t *testing.T) {
 				actualResponse := &model.SearchResponse{}
 				_ = json.Unmarshal(recorder.Body.Bytes(), actualResponse)
 
-				So(actualResponse.TotalResults, ShouldEqual, mockSearchResponse.TotalResults)
-				So(actualResponse.Results[0].ID, ShouldEqual, mockSearchResponse.Results[0].ID)
-				So(actualResponse.Results[1].ID, ShouldEqual, mockSearchResponse.Results[1].ID)
+				So(actualResponse.TotalResults, ShouldEqual, mockSuggestResponse.TotalResults)
+				So(actualResponse.Results[0].ID, ShouldEqual, mockSuggestResponse.Results[0].ID)
 			})
 		})
 	})
@@ -208,7 +207,7 @@ func Test(t *testing.T) {
 				return nil, errors.New("search client error")
 			}
 			handler.SearchClient = mockSearchClient
-			handler.Search(recorder, request)
+			handler.Suggest(recorder, request)
 
 			Convey("Then the result has an empty results array", func() {
 				So(recorder.Code, ShouldEqual, http.StatusOK)
@@ -233,13 +232,13 @@ func Test(t *testing.T) {
 			mockSearchClient.CustomQueryFunc = func(term string, index string) (*model.SearchResponse, error) {
 
 				if index == config.ElasticSearchIndex {
-					return mockSearchResponse, nil
+					return mockSuggestResponse, nil
 				}
 
 				return nil, errors.New("search client error")
 			}
 			handler.SearchClient = mockSearchClient
-			handler.Search(recorder, request)
+			handler.Suggest(recorder, request)
 
 			Convey("Then the result has an empty results array", func() {
 				So(recorder.Code, ShouldEqual, http.StatusOK)

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func listenForHTTPRequests(exitCh chan struct{}) {
 		router := pat.New()
 		router.Get("/healthcheck", healthcheck.Handler)
 		router.Get("/search", handler.Search)
+		router.Get("/suggest", handler.Suggest)
 		log.Debug("Starting HTTP server", log.Data{"bind_addr": config.BindAddr})
 
 		middleware := []alice.Constructor{

--- a/model/document.go
+++ b/model/document.go
@@ -2,7 +2,7 @@ package model
 
 // Document contains the base properties for all documents stored in Elastic Search.
 type Document struct {
-	ID   string      `json:"id"`
+	ID   string      `json:"id,omitempty"`
 	Type string      `json:"type"`
 	Body interface{} `json:"body"`
 }

--- a/model/searchResponse.go
+++ b/model/searchResponse.go
@@ -2,6 +2,6 @@ package model
 
 type SearchResponse struct {
 	TotalResults int64       `json:"total_results"`
-	AreaResults  []*Document `json:"area_results"`
+	AreaResults  []*Document `json:"area_results,omitempty"`
 	Results      []*Document `json:"results"`
 }

--- a/search/client.go
+++ b/search/client.go
@@ -70,7 +70,6 @@ func (elasticSearch *elasticSearchClient) Suggest(term string) (*model.SearchRes
 	query := elastic.NewMatchPhrasePrefixQuery("body.title", term)
 	builder.FetchSourceContext(fetchSourceContext).Query(query)
 
-
 	result, err := builder.
 		Index("dd").
 		Size(10).

--- a/search/client.go
+++ b/search/client.go
@@ -10,6 +10,7 @@ import (
 // QueryClient - interface for query functions on the search client.
 type QueryClient interface {
 	Query(term string, index string) (*model.SearchResponse, error)
+	Suggest(term string) (*model.SearchResponse, error)
 	Stop()
 }
 
@@ -30,6 +31,49 @@ func (elasticSearch *elasticSearchClient) Query(term string, index string) (*mod
 	result, err := builder.
 		Index(index).
 		From(0).Size(10).
+		Pretty(true).
+		Do()
+
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("Query took %d milliseconds\n", result.TookInMillis)
+
+	var document model.Document
+	var documents []*model.Document
+	for _, item := range result.Each(reflect.TypeOf(document)) {
+		t := item.(model.Document)
+		documents = append(documents, &t)
+	}
+
+	response := &model.SearchResponse{
+		TotalResults: result.TotalHits(),
+		Results:      documents,
+	}
+
+	return response, nil
+}
+
+func (elasticSearch *elasticSearchClient) Suggest(term string) (*model.SearchResponse, error) {
+	builder := elasticSearch.client.Search()
+
+	if len(term) <= 0 {
+		response := &model.SearchResponse{
+			TotalResults: 0,
+			Results:      []*model.Document{},
+		}
+		return response, nil
+	}
+
+	fetchSourceContext := elastic.NewFetchSourceContext(true).Exclude("body.dimensions", "body.metadata")
+	query := elastic.NewMatchPhrasePrefixQuery("body.title", term)
+	builder.FetchSourceContext(fetchSourceContext).Query(query)
+
+
+	result, err := builder.
+		Index("dd").
+		Size(10).
 		Pretty(true).
 		Do()
 

--- a/search/searchtest/mockSearchClient.go
+++ b/search/searchtest/mockSearchClient.go
@@ -30,5 +30,16 @@ func (elasticSearch *MockSearchClient) Query(term string, index string) (*model.
 	return nil, nil
 }
 
+// Query - just capture the query request for later assertion.
+func (elasticSearch *MockSearchClient) Suggest(term string) (*model.SearchResponse, error) {
+
+	if elasticSearch.CustomQueryFunc != nil {
+		return elasticSearch.CustomQueryFunc(term, "dd")
+	}
+
+	elasticSearch.QueryRequests = append(elasticSearch.QueryRequests, term)
+	return nil, nil
+}
+
 // Stop - mock implementation does nothing.
 func (elasticSearch *MockSearchClient) Stop() {}

--- a/vendor/github.com/smartystreets/assertions/equality.go
+++ b/vendor/github.com/smartystreets/assertions/equality.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/smartystreets/assertions/internal/oglematchers"
 	"github.com/smartystreets/assertions/internal/go-render/render"
+	"github.com/smartystreets/assertions/internal/oglematchers"
 )
 
 // default acceptable delta for ShouldAlmostEqual

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/transform_description.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/transform_description.go
@@ -23,7 +23,7 @@ func transformDescription(m Matcher, newDesc string) Matcher {
 }
 
 type transformDescriptionMatcher struct {
-	desc string
+	desc           string
 	wrappedMatcher Matcher
 }
 


### PR DESCRIPTION
### What

- Added endpoint for auto-complete
- Using our own snowball analyzer instead of default one with elastic search's suggest

### How to review

Check out the new `/suggest?q=<search>` out 😎 